### PR TITLE
fix: correct stream completion detection in OpenAI response

### DIFF
--- a/Core/Sources/CodeCompletionService/API/OpenAIService.swift
+++ b/Core/Sources/CodeCompletionService/API/OpenAIService.swift
@@ -170,7 +170,7 @@ extension OpenAIService {
                     ChatCompletionsStreamDataChunk.self,
                     from: text.data(using: .utf8) ?? Data()
                 )
-                return .init(chunk: chunk, done: chunk.choices?.first?.delta?.content != nil)
+                return .init(chunk: chunk, done: chunk.choices?.first?.finish_reason != nil)
             } catch {
                 print(error)
                 throw error


### PR DESCRIPTION
The stream was not properly detecting completion state in chat responses. Changed the done condition to check for finish_reason presence instead of relying on content parsing. This fixes premature stream termination and ensures all response chunks are properly processed.