### PR TITLE
Add Anthropic API support (Claude) for code completion

### DIFF
--- a/Core/Sources/CodeCompletionService/API/AnthropicService.swift
+++ b/Core/Sources/CodeCompletionService/API/AnthropicService.swift
@@ -1,0 +1,235 @@
+import CopilotForXcodeKit
+import Foundation
+import Fundamental
+
+public actor AnthropicService {
+    let url: URL
+    let modelName: String
+    let contextWindow: Int
+    let maxToken: Int
+    let temperature: Double
+    let apiKey: String
+    let stopWords: [String]
+
+    init(
+        url: String? = nil,
+        modelName: String,
+        contextWindow: Int,
+        maxToken: Int,
+        temperature: Double = 0.2,
+        stopWords: [String] = [],
+        apiKey: String
+    ) {
+        self.url = url.flatMap(URL.init(string:)) ??
+            URL(string: "https://api.anthropic.com/v1/messages")!
+        self.modelName = modelName
+        self.maxToken = maxToken
+        self.temperature = temperature
+        self.apiKey = apiKey
+        self.stopWords = stopWords
+        self.contextWindow = contextWindow
+    }
+
+    public enum Models: String, CaseIterable {
+        case claude3Opus = "claude-3-opus-latest"
+        case claude35Sonnet = "claude-3-5-sonnet-latest"
+        case claude35Haiku = "claude-3-5-haiku-latest"
+
+        var maxToken: Int {
+            switch self {
+            case .claude3Opus: return 4096
+            case .claude35Sonnet: return 4096
+            case .claude35Haiku: return 4096
+            }
+        }
+    }
+}
+
+// MARK: - CodeCompletionServiceType Implementation
+
+extension AnthropicService: CodeCompletionServiceType {
+    func getCompletion(_ request: PromptStrategy) async throws -> AsyncStream<String> {
+        let (messages, systemPrompt) = createMessages(from: request)
+        CodeCompletionLogger.logger.logPrompt(messages.map {
+            ($0.content, $0.role.rawValue)
+        })
+        let result = try await sendMessages(messages, systemPrompt: systemPrompt)
+        return result.compactMap { $0.delta?.text }.eraseToStream()
+    }
+}
+
+// MARK: - Message Structure and Request Handling
+
+extension AnthropicService {
+    public struct Message: Codable {
+        public enum Role: String, Codable {
+            case user
+            case assistant
+        }
+
+        var role: Role
+        var content: String
+    }
+
+    struct MessageRequestBody: Codable {
+        var model: String
+        var messages: [Message]
+        var system: String?
+        var max_tokens: Int
+        var temperature: Double
+        var stream: Bool = true
+        var stop_sequences: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case messages
+            case system
+            case max_tokens
+            case temperature
+            case stream
+            case stop_sequences
+        }
+    }
+
+    func createMessages(from request: PromptStrategy) -> (messages: [Message], system: String?) {
+        let strategy = DefaultTruncateStrategy(maxTokenLimit: max(
+            contextWindow / 3 * 2,
+            contextWindow - maxToken - 20
+        ))
+        let prompts = strategy.createTruncatedPrompt(promptStrategy: request)
+
+        let systemPrompt = request.systemPrompt
+
+        let messages = prompts.map { prompt in
+            Message(
+                role: prompt.role == .user ? .user : .assistant,
+                content: prompt.content
+            )
+        }
+
+        return (messages: messages, system: systemPrompt)
+    }
+
+    func sendMessages(_ messages: [Message], systemPrompt: String?) async throws -> ResponseStream<StreamResponse> {
+        let validStopSequences = stopWords.filter {
+            !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        let requestBody = MessageRequestBody(
+            model: modelName,
+            messages: messages,
+            system: systemPrompt,
+            max_tokens: maxToken,
+            temperature: temperature,
+            stop_sequences: validStopSequences
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue("\(apiKey)", forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+
+        let encoder = JSONEncoder()
+        request.httpBody = try encoder.encode(requestBody)
+
+        let (result, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CancellationError()
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let text = try await result.lines.reduce(into: "") { partialResult, current in
+                partialResult += current
+            }
+            throw Error.otherError(text)
+        }
+
+        return ResponseStream(result: result) {
+            var text = $0
+
+            if text.hasPrefix("event: ") {
+                return .init(chunk: StreamResponse(), done: false)
+            }
+
+            if text.hasPrefix("data: ") {
+                text = String(text.dropFirst(6))
+
+                guard !text.trimmingCharacters(in: .whitespaces).isEmpty else {
+                    return .init(chunk: StreamResponse(), done: false)
+                }
+
+                do {
+                    let chunk = try JSONDecoder().decode(
+                        StreamResponse.self,
+                        from: text.data(using: .utf8) ?? Data()
+                    )
+                    return .init(
+                        chunk: chunk,
+                        done: chunk.type == "message_stop"
+                    )
+                } catch {
+                    print("Error decoding chunk: \(error)")
+                    throw error
+                }
+            }
+
+            return .init(chunk: StreamResponse(), done: false)
+        }
+    }
+}
+
+// MARK: - API Response Structures
+
+extension AnthropicService {
+    struct StreamResponse: Decodable {
+        var type: String?
+        var delta: Delta?
+        var index: Int?
+        var content: [Content]?
+
+        struct Delta: Decodable {
+            var text: String?
+            var type: String?
+        }
+
+        struct Content: Decodable {
+            var text: String
+            var type: String
+        }
+    }
+
+    struct APIError: Decodable {
+        var type: String
+        var message: String
+        var code: String?
+    }
+
+    enum Error: Swift.Error, LocalizedError {
+        case decodeError(Swift.Error)
+        case apiError(APIError)
+        case otherError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .decodeError(error):
+                return error.localizedDescription
+            case let .apiError(error):
+                return error.message
+            case let .otherError(message):
+                return message
+            }
+        }
+    }
+}
+
+// MARK: - Helper Methods
+
+extension AnthropicService {
+    func validateResponse(_ response: HTTPURLResponse) throws {
+        guard (200 ... 299).contains(response.statusCode) else {
+            throw Error.otherError("HTTP Error: \(response.statusCode)")
+        }
+    }
+}

--- a/Core/Sources/CodeCompletionService/API/AnthropicService.swift
+++ b/Core/Sources/CodeCompletionService/API/AnthropicService.swift
@@ -35,11 +35,11 @@ public actor AnthropicService {
         case claude35Sonnet = "claude-3-5-sonnet-latest"
         case claude35Haiku = "claude-3-5-haiku-latest"
 
-        var maxToken: Int {
+        public var maxToken: Int {
             switch self {
-            case .claude3Opus: return 4096
-            case .claude35Sonnet: return 4096
-            case .claude35Haiku: return 4096
+            case .claude3Opus: return 200_000
+            case .claude35Sonnet: return 200_000
+            case .claude35Haiku: return 200_000
             }
         }
     }

--- a/Core/Sources/CodeCompletionService/CodeCompletionService.swift
+++ b/Core/Sources/CodeCompletionService/CodeCompletionService.swift
@@ -159,6 +159,22 @@ public struct CodeCompletionService {
             )
             try Task.checkCancellation()
             return result
+        case .anthropic:
+            let service = AnthropicService(
+                url: model.endpoint,
+                modelName: model.info.modelName,
+                contextWindow: model.info.maxTokens,
+                maxToken: UserDefaults.shared.value(for: \.maxGenerationToken),
+                stopWords: prompt.stopWords,
+                apiKey: apiKey
+            )
+            let result = try await service.getCompletions(
+                prompt,
+                streamStopStrategy: streamStopStrategy,
+                count: count
+            )
+            try Task.checkCancellation()
+            return result
         case .unknown:
             throw Error.unknownFormat
         }

--- a/Core/Sources/CodeCompletionService/CodeCompletionService.swift
+++ b/Core/Sources/CodeCompletionService/CodeCompletionService.swift
@@ -159,7 +159,7 @@ public struct CodeCompletionService {
             )
             try Task.checkCancellation()
             return result
-        case .anthropic:
+        case .claude:
             let service = AnthropicService(
                 url: model.endpoint,
                 modelName: model.info.modelName,

--- a/Core/Sources/Fundamental/Models/ChatModel.swift
+++ b/Core/Sources/Fundamental/Models/ChatModel.swift
@@ -23,6 +23,7 @@ public struct ChatModel: Codable, Equatable, Identifiable {
         case openAICompatible
         case googleAI
         case ollama
+        case anthropic
 
         case unknown
     }
@@ -110,6 +111,10 @@ public struct ChatModel: Codable, Equatable, Identifiable {
             let baseURL = info.baseURL
             if baseURL.isEmpty { return "http://localhost:11434/api/chat" }
             return "\(baseURL)/api/chat"
+        case .anthropic:
+            let baseURL = info.baseURL
+            if baseURL.isEmpty { return "https://api.anthropic.com/v1/messages" }
+            return "\(baseURL)/v1/messages"
         case .unknown:
             return ""
         }

--- a/Core/Sources/Fundamental/Models/ChatModel.swift
+++ b/Core/Sources/Fundamental/Models/ChatModel.swift
@@ -23,7 +23,7 @@ public struct ChatModel: Codable, Equatable, Identifiable {
         case openAICompatible
         case googleAI
         case ollama
-        case anthropic
+        case claude
 
         case unknown
     }
@@ -111,7 +111,7 @@ public struct ChatModel: Codable, Equatable, Identifiable {
             let baseURL = info.baseURL
             if baseURL.isEmpty { return "http://localhost:11434/api/chat" }
             return "\(baseURL)/api/chat"
-        case .anthropic:
+        case .claude:
             let baseURL = info.baseURL
             if baseURL.isEmpty { return "https://api.anthropic.com/v1/messages" }
             return "\(baseURL)/v1/messages"

--- a/Core/Sources/SuggestionService/RequestStrategies/AnthropicRequestStrategy.swift
+++ b/Core/Sources/SuggestionService/RequestStrategies/AnthropicRequestStrategy.swift
@@ -1,0 +1,162 @@
+import CodeCompletionService
+import CopilotForXcodeKit
+import Foundation
+import Fundamental
+
+/// Request strategy optimized for Anthropic's Claude API.
+///
+/// This strategy is specifically designed to work with Claude's message API format,
+/// providing clear and strict instructions for code completion tasks.
+struct AnthropicRequestStrategy: RequestStrategy {
+    var sourceRequest: SuggestionRequest
+    var prefix: [String]
+    var suffix: [String]
+
+    var shouldSkip: Bool {
+        prefix.last?.trimmingCharacters(in: .whitespaces) == "}"
+    }
+
+    func createPrompt() -> Prompt {
+        Prompt(
+            sourceRequest: sourceRequest,
+            prefix: prefix,
+            suffix: suffix
+        )
+    }
+
+    func createStreamStopStrategy(model _: Service.Model) -> some StreamStopStrategy {
+        OpeningTagBasedStreamStopStrategy(
+            openingTag: Tag.openingCode,
+            toleranceIfNoOpeningTagFound: 0 // Claude is more precise, we don't need tolerance
+        )
+    }
+
+    func createRawSuggestionPostProcessor() -> DefaultRawSuggestionPostProcessingStrategy {
+        DefaultRawSuggestionPostProcessingStrategy(codeWrappingTags: (
+            Tag.openingCode,
+            Tag.closingCode
+        ))
+    }
+
+    enum Tag {
+        public static let openingCode = "<Code3721>"
+        public static let closingCode = "</Code3721>"
+        public static let openingSnippet = "<Snippet9981>"
+        public static let closingSnippet = "</Snippet9981>"
+    }
+
+    struct Prompt: PromptStrategy {
+        let systemPrompt: String = """
+        You are a code completion AI with the following STRICT rules:
+        1. You MUST ONLY output code within \(Tag.openingCode) and \(Tag.closingCode) tags
+        2. You MUST NEVER add explanations, comments, or any text outside the tags
+        3. You MUST continue the code exactly where it was left off
+        4. You MUST maintain the same style, patterns, and conventions present in the surrounding code
+        5. You MUST NOT include any markdown formatting or code block symbols
+
+        Example - if given:
+        Complete code inside \(Tag.openingCode):
+
+        \(Tag.openingCode)
+        print("Hello
+        \(Tag.closingCode)
+
+        You MUST respond EXACTLY:
+        \(Tag.openingCode) World")\(Tag.closingCode)
+
+        CRITICAL REQUIREMENTS:
+        - Start IMMEDIATELY with \(Tag.openingCode)
+        - End IMMEDIATELY with \(Tag.closingCode)
+        - NO text before or after the tags
+        - NO explanations
+        - NO markdown
+        - NO commentary
+        """.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var sourceRequest: SuggestionRequest
+        var prefix: [String]
+        var suffix: [String]
+        var filePath: String { sourceRequest.relativePath ?? sourceRequest.fileURL.path }
+        var relevantCodeSnippets: [RelevantCodeSnippet] { sourceRequest.relevantCodeSnippets }
+        var stopWords: [String] { [Tag.closingCode] } // Removed "\n\n" as Claude does not accept whitespace-only sequences
+        var language: CodeLanguage? { sourceRequest.language }
+
+        var suggestionPrefix: SuggestionPrefix {
+            guard let prefix = prefix.last else { return .empty }
+            return .unchanged(prefix).curlyBracesLineBreak()
+        }
+
+        func createPrompt(
+            truncatedPrefix: [String],
+            truncatedSuffix: [String],
+            includedSnippets: [RelevantCodeSnippet]
+        ) -> [PromptMessage] {
+            return [.init(role: .user, content: [
+                Self.createSnippetsPrompt(includedSnippets: includedSnippets),
+                createSourcePrompt(
+                    truncatedPrefix: truncatedPrefix,
+                    truncatedSuffix: truncatedSuffix
+                ),
+            ].filter { !$0.isEmpty }.joined(separator: "\n\n"))]
+        }
+
+        func createSourcePrompt(truncatedPrefix: [String], truncatedSuffix: [String]) -> String {
+            guard let (summary, infillBlock) = Self.createCodeSummary(
+                truncatedPrefix: truncatedPrefix,
+                truncatedSuffix: truncatedSuffix,
+                suggestionPrefix: suggestionPrefix.infillValue
+            ) else { return "" }
+
+            return """
+            Below is the code from file \(filePath) that needs completion.
+            You MUST:
+            1. Analyze the code's style, patterns, and conventions
+            2. Complete the code maintaining exact formatting
+            3. Only output code within \(Tag.openingCode) tags
+            4. Never duplicate existing implementations
+
+            File: \(filePath)
+            Indentation: \(sourceRequest.indentSize) \(sourceRequest.usesTabsForIndentation ? "tab" : "space")
+
+            Code to complete:
+            \(summary)
+
+            Complete code inside \(Tag.openingCode):
+
+            \(Tag.openingCode)\(infillBlock)
+            """.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        static func createSnippetsPrompt(includedSnippets: [RelevantCodeSnippet]) -> String {
+            guard !includedSnippets.isEmpty else { return "" }
+            return """
+            Reference code (analyze for patterns and conventions):
+
+            \(includedSnippets.map { snippet in
+                "\(Tag.openingSnippet)\n\(snippet.content)\n\(Tag.closingSnippet)"
+            }.joined(separator: "\n\n"))
+            """.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        static func createCodeSummary(
+            truncatedPrefix: [String],
+            truncatedSuffix: [String],
+            suggestionPrefix: String
+        ) -> (summary: String, infillBlock: String)? {
+            guard !(truncatedPrefix.isEmpty && truncatedSuffix.isEmpty) else { return nil }
+            let promptLinesCount = min(10, max(truncatedPrefix.count, 2))
+            let prefixLines = truncatedPrefix.prefix(
+                max(0, truncatedPrefix.count - promptLinesCount)
+            )
+            let promptLines: [String] = {
+                let proposed = truncatedPrefix.suffix(promptLinesCount)
+                return Array(proposed.dropLast()) + [suggestionPrefix]
+            }()
+
+            return (
+                summary: "\(prefixLines.joined())\(Tag.openingCode)\(Tag.closingCode)\(truncatedSuffix.joined())",
+                infillBlock: promptLines.joined()
+            )
+        }
+    }
+}

--- a/Core/Sources/SuggestionService/RequestStrategy.swift
+++ b/Core/Sources/SuggestionService/RequestStrategy.swift
@@ -33,6 +33,7 @@ public enum RequestStrategyOption: String, CaseIterable, Codable {
     case `continue`
     case codeLlamaFillInTheMiddle
     case codeLlamaFillInTheMiddleWithSystemPrompt
+    case anthropic
 }
 
 extension RequestStrategyOption {
@@ -48,6 +49,8 @@ extension RequestStrategyOption {
             return FillInTheMiddleRequestStrategy.self
         case .codeLlamaFillInTheMiddleWithSystemPrompt:
             return FillInTheMiddleWithSystemPromptRequestStrategy.self
+        case .anthropic:
+            return AnthropicRequestStrategy.self
         }
     }
 }

--- a/CustomSuggestionService/ChatModelManagement/ChatModelEdit.swift
+++ b/CustomSuggestionService/ChatModelManagement/ChatModelEdit.swift
@@ -100,6 +100,13 @@ struct ChatModelEdit {
                         state.suggestedMaxTokens = nil
                     }
                     return .none
+                case .claude:
+                    if let knownModel = AnthropicService.Models(rawValue: state.modelName) {
+                        state.suggestedMaxTokens = knownModel.maxToken
+                    } else {
+                        state.suggestedMaxTokens = nil
+                    }
+                    return .none
                 default:
                     state.suggestedMaxTokens = nil
                     return .none

--- a/CustomSuggestionService/ChatModelManagement/ChatModelEditView.swift
+++ b/CustomSuggestionService/ChatModelManagement/ChatModelEditView.swift
@@ -27,6 +27,8 @@ struct ChatModelEditView: View {
                             googleAI
                         case .ollama:
                             ollama
+                        case .anthropic:
+                            anthropic
                         case .unknown:
                             EmptyView()
                         }
@@ -81,6 +83,8 @@ struct ChatModelEditView: View {
                         Text("Google Generative AI").tag(format)
                     case .ollama:
                         Text("Ollama").tag(format)
+                    case .anthropic:
+                        Text("Anthropic").tag(format)
                     case .unknown:
                         EmptyView()
                     }
@@ -285,6 +289,40 @@ struct ChatModelEditView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(Image(systemName: "exclamationmark.triangle.fill")) + Text(
                 " For more details, please visit [https://ollama.com](https://ollama.com)."
+            )
+        }
+        .padding(.vertical)
+    }
+
+    @ViewBuilder
+    var anthropic: some View {
+        baseURLTextField(prompt: Text("https://api.anthropic.com")) {
+            Text("/v1/messages")
+        }
+        apiKeyNamePicker
+
+        TextField("Model Name", text: $store.modelName)
+            .overlay(alignment: .trailing) {
+                Picker(
+                    "",
+                    selection: $store.modelName,
+                    content: {
+                        if AnthropicService.Models(rawValue: store.modelName) == nil {
+                            Text("Custom Model").tag(store.modelName)
+                        }
+                        ForEach(AnthropicService.Models.allCases, id: \.self) { model in
+                            Text(model.rawValue).tag(model.rawValue)
+                        }
+                    }
+                )
+                .frame(width: 20)
+            }
+
+        maxTokensTextField
+
+        VStack(alignment: .leading, spacing: 8) {
+            Text(Image(systemName: "exclamationmark.triangle.fill")) + Text(
+                " For more details, please visit [https://anthropic.com](https://anthropic.com)."
             )
         }
         .padding(.vertical)

--- a/CustomSuggestionService/ChatModelManagement/ChatModelEditView.swift
+++ b/CustomSuggestionService/ChatModelManagement/ChatModelEditView.swift
@@ -27,8 +27,8 @@ struct ChatModelEditView: View {
                             googleAI
                         case .ollama:
                             ollama
-                        case .anthropic:
-                            anthropic
+                        case .claude:
+                            claude
                         case .unknown:
                             EmptyView()
                         }
@@ -83,8 +83,8 @@ struct ChatModelEditView: View {
                         Text("Google Generative AI").tag(format)
                     case .ollama:
                         Text("Ollama").tag(format)
-                    case .anthropic:
-                        Text("Anthropic").tag(format)
+                    case .claude:
+                        Text("Claude").tag(format)
                     case .unknown:
                         EmptyView()
                     }
@@ -295,7 +295,7 @@ struct ChatModelEditView: View {
     }
 
     @ViewBuilder
-    var anthropic: some View {
+    var claude: some View {
         baseURLTextField(prompt: Text("https://api.anthropic.com")) {
             Text("/v1/messages")
         }

--- a/CustomSuggestionService/ContentView.swift
+++ b/CustomSuggestionService/ContentView.swift
@@ -222,6 +222,9 @@ struct RequestStrategyPicker: View {
                     case .codeLlamaFillInTheMiddleWithSystemPrompt:
                         Text("Fill-in-the-Middle with System Prompt")
                             .tag(option.rawValue)
+                    case .anthropic:
+                        Text("Anthropic optimized")
+                            .tag(option.rawValue)
                     }
                 }
             }


### PR DESCRIPTION
# Description
This PR adds support for Anthopic models (Claude) to be used in code completion/suggestion tasks using the `/v1/messages` endpoint.

- `AnthropicService` is used to connect with Anthopic APIs and process the stream response. It has the following predefined models:
  - Sonnet 3.5 latest
  - Haiku 3.5 latest
  - Opus 3.0 latest 
- `AnthropicRequestStrategy` was created to set custom "Anthropic Optimized" prompts to work with the APIs (I tried the default prompts but it returns a suggestion with explanation and not just code)

Also UI was updated to set up API endpoint (Chat completion API section) and request strategy.

# Screenshots

## Main Screen

<img width="912" alt="Screenshot 2024-12-26 at 10 20 24" src="https://github.com/user-attachments/assets/22adb8db-7c6e-4358-9579-676a4623ef14" />

## API Setup

<img width="1014" alt="Screenshot 2024-12-26 at 10 11 56" src="https://github.com/user-attachments/assets/11629b6b-dc31-4908-accd-4d95920316fe" />
